### PR TITLE
Remove unneeded commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
 FROM tomcat:8.5-jdk11-openjdk
 MAINTAINER Karl Dahlgren <karl.dahlgren@castlemock.com>
 
-# Delete the default applications
-RUN rm -rf /usr/local/tomcat/webapps/ROOT
-RUN rm -rf /usr/local/tomcat/webapps/docs
-RUN rm -rf /usr/local/tomcat/webapps/examples
-RUN rm -rf /usr/local/tomcat/webapps/manager
-RUN rm -rf /usr/local/tomcat/webapps/host-manager
-
 # Change directory to Tomcat webapps folder and download the latest Castle Mock war file
 RUN cd /usr/local/tomcat/webapps && curl -o castlemock.war -fSL https://github.com/castlemock/castlemock/releases/download/v1.50/castlemock.war
 


### PR DESCRIPTION
As of docker-library/tomcat#181, the upstream-provided (example) webapps are not enabled by default.