### PR TITLE
Add support for arm64

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,5 +33,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: castlemock/castlemock:latest,castlemock/castlemock:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Add support for the linux/arm64 architecture. This is needed to make the image compatible with Apple Silicon (M1) Mac's.